### PR TITLE
fix: selecting english translation shows polish

### DIFF
--- a/languages/pl.json
+++ b/languages/pl.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "iso": "en",
+    "iso": "pl",
     "value": "polish",
     "display_name": "Polski"
   },


### PR DESCRIPTION
I love sharing this site with friends and encouraging them to learn about Nano.  Today I noticed there was an issue, so here is a very small PR to fix it.  

Issue steps:
1. select English from the dropdown
2. observe that the Polish translation shows.

Solution:
In the Polish translation file update iso from "en" to "pl"